### PR TITLE
Update Redis.php

### DIFF
--- a/src/Repositories/Redis.php
+++ b/src/Repositories/Redis.php
@@ -35,10 +35,10 @@ class Redis extends Repository
 
     public function retrieve($user)
     {
-        $data = json_decode($this->storage->get('usr.' . $user->getKey() . '.lastSeen'),true);
+        $data = json_decode($this->storage->get('usr.' . $user->getKey() . '.lastSeen'));
 
         // Make the stored date into Carbon object
-        $data['date'] = Carbon::createFromFormat('Y-m-d H:i:s', $data['date']);
+        $data->date = Carbon::createFromFormat('Y-m-d H:i:s', $data->date);
 
         return $data;
     }


### PR DESCRIPTION
Add object behavior:D

but i get error message when i use
FatalErrorException in Redis.php line 41:
Cannot use object of type stdClass as array

Because the data is not array in
$data = json_decode($this->storage->get('usr.' . $user->getKey() . '.lastSeen')); // this si object

 // Make the stored date into Carbon object
$data['date'] = Carbon::createFromFormat('Y-m-d H:i:s', $data['date']);

If you set $data['date'] = Carbon::createFromFormat('Y-m-d H:i:s', $data->date); then it will work but it wont return requests

or 
$data->date =  Carbon::createFromFormat('Y-m-d H:i:s',  $data->date);
return $data

Thanks:D
